### PR TITLE
chore: rename module to charmbracelet/console

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
       with:
-        path: src/github.com/containerd/console
+        path: src/github.com/charmbracelet/console
         fetch-depth: 25
 
     - name: Install dependencies
@@ -39,14 +39,14 @@ jobs:
     - name: Project Checks
       uses: containerd/project-checks@v1.1.0
       with:
-        working-directory: src/github.com/containerd/console
+        working-directory: src/github.com/charmbracelet/console
 
     - name: Go Linting
       run: GOGC=75 golangci-lint run
-      working-directory: src/github.com/containerd/console
+      working-directory: src/github.com/charmbracelet/console
 
     - name: Build & Test
-      working-directory: src/github.com/containerd/console
+      working-directory: src/github.com/charmbracelet/console
       run: |
         go test -race
         GOOS=openbsd go build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # console
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/containerd/console)](https://pkg.go.dev/github.com/containerd/console)
-[![Build Status](https://github.com/containerd/console/workflows/CI/badge.svg)](https://github.com/containerd/console/actions?query=workflow%3ACI)
-[![Go Report Card](https://goreportcard.com/badge/github.com/containerd/console)](https://goreportcard.com/report/github.com/containerd/console)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/charmbracelet/console)](https://pkg.go.dev/github.com/charmbracelet/console)
+[![Build Status](https://github.com/charmbracelet/console/workflows/CI/badge.svg)](https://github.com/charmbracelet/console/actions?query=workflow%3ACI)
+[![Go Report Card](https://goreportcard.com/badge/github.com/charmbracelet/console)](https://goreportcard.com/report/github.com/charmbracelet/console)
 
 Golang package for dealing with consoles.  Light on deps and a simple API.
 
@@ -20,10 +20,7 @@ current.Resize(ws)
 
 ## Project details
 
-console is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
-As a containerd sub-project, you will find the:
- * [Project governance](https://github.com/containerd/project/blob/main/GOVERNANCE.md),
- * [Maintainers](https://github.com/containerd/project/blob/main/MAINTAINERS),
- * and [Contributing guidelines](https://github.com/containerd/project/blob/main/CONTRIBUTING.md)
-
-information in our [`containerd/project`](https://github.com/containerd/project) repository.
+console is a friendly fork of
+[containerd/console](https://github.com/containerd/console), licensed under the
+[Apache 2.0 license](./LICENSE), with the objective of supporting more operating
+systems.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/containerd/console
+module github.com/charmbracelet/console
 
 go 1.13
 


### PR DESCRIPTION
This is needed before this module can be used. In its current state:

```console
$ go get github.com/charmbracelet/console@latest
go: downloading github.com/charmbracelet/console v0.0.0-20230623181844-2d4e8fb351e4
go: github.com/charmbracelet/console@v0.0.0-20230623181844-2d4e8fb351e4: parsing go.mod:
        module declares its path as: github.com/containerd/console
                but was required as: github.com/charmbracelet/console
```